### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## \[Unreleased]
+
+## \[0.3.0] - 2024-04-06
+
+### Added
+
+- Added `OneOf::subset()`.
+- Implemented `Clone` for `OneOf` where all variants are `Clone`.
+
+## \[0.2.6] - 2024-04-02
+
+### Added
+
+- Added `OneOf::to_enum()` and `OneOf::as_enum()`.
+
+## \[0.2.5] - 2024-04-01
+
+- Implement `Debug`, `Display` and `Error` if all types in the `OneOf` implement them.
+
+## \[0.2.4] - 2024-03-31
+
+## \[0.2.3] - 2024-03-31
+
+## \[0.2.2] - 2024-03-31
+
+## \[0.2.1] - 2024-03-31
+
+### Added
+
+- Added support for tuples up to length 9.
+
+## \[0.2.0] - 2024-03-31
+
+### Added
+
+- Added `OneOf::take()`.
+- Implemented `Deref<Target = T>` for `OneOf<(T,)>`.
+
+## \[0.1.6] - 2024-03-31
+
+## \[0.1.4] - 2024-03-31
+
+## \[0.1.3] - 2024-03-31
+
+## \[0.1.2] - 2024-03-31
+
+### Added
+
+- Added `OneOf::broaden()`.
+
+## \[0.1.1] - 2024-03-30
+
+### Fixed
+
+- Miscellaneous fixes and cleanups.
+
+## \[0.1.0] - 2024-03-30
+
+Initial release.


### PR DESCRIPTION
Even though this is a new project, keeping up with its releases and navigating the history is already unnecessarily hard. At least for me.

I summed up the history in a basic changelog. I didn't want to clutter it (and spend much time on it), so it doesn't include changes in implementation traits, documentation or tests. Only "notable" changes to `OneOf`. I hope, you don't mind maintaining it. Feel free to make edits before merging.

To simplify the process, I also added tags like `0.3.0` on commits that modify the version in `Cargo.toml`. But it turns out that I can't move them over a pull request. Consider adding tags yourself, this sloudn't take much time. This simplifies git log navigation and also allows Github to autogenerate releases.