### PR TITLE
feat: :sparkles: Add axums IntoResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terrors"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Tyler Neely <tylerneely@gmail.com>"]
 documentation = "https://docs.rs/terrors/"
@@ -14,3 +14,7 @@ readme = "README.md"
 [features]
 error_provide = []
 error_provide_feature = []
+axum = ["axum-core"]
+
+[dependencies]
+axum-core = { version = "0.5.0", optional = true }

--- a/src/one_of.rs
+++ b/src/one_of.rs
@@ -4,10 +4,17 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 use std::error::Error;
 
+#[cfg(feature = "axum")]
+use crate::type_set::ResponseFold;
 use crate::type_set::{
     CloneFold, Contains, DebugFold, DisplayFold, ErrorFold, IsFold, Narrow, SupersetOf, TupleForm,
     TypeSet,
 };
+#[cfg(feature = "axum")]
+use axum_core::response::IntoResponse;
+
+#[cfg(feature = "axum")]
+use axum_core::response::Response;
 
 use crate::{Cons, End};
 
@@ -101,6 +108,17 @@ where
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         E::Variants::display_fold(&self.value, formatter)
+    }
+}
+
+#[cfg(feature = "axum")]
+impl<E> IntoResponse for OneOf<E>
+where
+    E: TypeSet,
+    E::Variants: IntoResponse + ResponseFold,
+{
+    fn into_response(self) -> Response {
+        E::Variants::response_fold(self.value)
     }
 }
 


### PR DESCRIPTION
This adds IntoResponse under the axum feature flag.
Very handy when creating a rest api because you see all possible errors this endpoint can throw. 